### PR TITLE
Add driver application to test concurrent operations

### DIFF
--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -16,38 +16,46 @@ namespace Client
 
             // when the server requests a file, open a stream to that file and POST it to /file/{filename}
             // as multipart form data (typical file upload content; there may be a more straightforward way to do this)
-            Connection.On<string>("REQUEST", async (filename) =>
-            {
-                try 
-                { 
-                    Console.WriteLine($"Server has requested {filename}. Opening...");
-
-                    using var stream = new FileStream(Path.Combine(@"C:\slsk-downloads", filename), FileMode.Open, FileAccess.Read);
-                    using var request = new HttpRequestMessage(HttpMethod.Post, $"file/{filename}");
-                    using var content = new MultipartFormDataContent
-                    {
-                        { new StreamContent(stream), "file", filename }
-                    };
-
-                    request.Content = content;
-
-                    Console.WriteLine($"Sending {filename}...");
-                    var response = await Client.SendAsync(request);
-
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        Console.WriteLine("Failed");
-                        Console.WriteLine(response.StatusCode);
-                    }
-                    else
-                    {
-                        Console.WriteLine("Sent!");
-                    }
-                }
-                catch (Exception ex)
+            Connection.On<string>("REQUEST", (filename) => {
+                _ = Task.Run(async () =>
                 {
-                    Console.WriteLine(ex);
-                }
+                    {
+                        try
+                        {
+                            Console.WriteLine($"Server has requested {filename}. Opening...");
+
+                            await Task.Delay(1000);
+
+                            using var stream = new FileStream(Path.Combine(@"C:\slsk-downloads", filename), FileMode.Open, FileAccess.Read);
+                            using var request = new HttpRequestMessage(HttpMethod.Post, $"file/{filename}");
+                            using var content = new MultipartFormDataContent
+                        {
+                            { new StreamContent(stream), "file", filename }
+                        };
+
+                            request.Content = content;
+
+                            Console.WriteLine($"Sending {filename}...");
+                            var response = await Client.SendAsync(request);
+
+                            if (!response.IsSuccessStatusCode)
+                            {
+                                Console.WriteLine("Failed");
+                                Console.WriteLine(response.StatusCode);
+                            }
+                            else
+                            {
+                                Console.WriteLine($"{filename} sent!");
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine(ex);
+                        }
+                    }
+                });
+
+                return Task.CompletedTask;
             });
 
             await Connection.StartAsync();

--- a/Driver/Driver.csproj
+++ b/Driver/Driver.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Driver/Program.cs
+++ b/Driver/Program.cs
@@ -1,0 +1,30 @@
+﻿using System.Net;
+
+namespace Driver
+{
+    internal class Program
+    {
+        private static readonly HttpClient Client = new HttpClient() { BaseAddress = new("https://localhost:7250"),  };
+
+        static async Task Main(string[] args)
+        {
+            await Task.WhenAll(Enumerable.Range(1, 20).Select(n => Get(n)));
+            Console.WriteLine("Done");
+        }
+
+        static async Task Get(int num)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"file/{num}.mp3");
+            var response = await Client.SendAsync(request);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                Console.WriteLine($"{num} failed! {response.StatusCode}");
+            }
+            else
+            {
+                Console.WriteLine($"{num} succeeded!");
+            }
+        }
+    }
+}

--- a/HTTPSStreaming.sln
+++ b/HTTPSStreaming.sln
@@ -3,9 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server", "Server\Server.csproj", "{9F7E5C6B-B2C3-481C-823E-7DF839C16CA9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Server", "Server\Server.csproj", "{9F7E5C6B-B2C3-481C-823E-7DF839C16CA9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client", "Client\Client.csproj", "{7EAC4C2E-5EC7-4716-AD91-3267CDCB0CA1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Client", "Client\Client.csproj", "{7EAC4C2E-5EC7-4716-AD91-3267CDCB0CA1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Driver", "Driver\Driver.csproj", "{404B8ACA-D257-4945-B71E-3F454FFE1C71}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{7EAC4C2E-5EC7-4716-AD91-3267CDCB0CA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EAC4C2E-5EC7-4716-AD91-3267CDCB0CA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EAC4C2E-5EC7-4716-AD91-3267CDCB0CA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{404B8ACA-D257-4945-B71E-3F454FFE1C71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{404B8ACA-D257-4945-B71E-3F454FFE1C71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{404B8ACA-D257-4945-B71E-3F454FFE1C71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{404B8ACA-D257-4945-B71E-3F454FFE1C71}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Server/Controllers/FileController.cs
+++ b/Server/Controllers/FileController.cs
@@ -31,7 +31,7 @@ namespace Server.Controllers
                 try
                 {
                     Console.WriteLine($"Added {filename} record. Waiting on file from link...");
-                    var task = await Task.WhenAny(tcs.Task, Task.Delay(5000));
+                    var task = await Task.WhenAny(tcs.Task, Task.Delay(60000));
 
                     if (task == tcs.Task)
                     {


### PR DESCRIPTION
A key requirement of this experiment is that the client can concurrently upload many files at a time, instead of processing requests from the server serially.

The SignalR `On()` handler is executed serially by default, so I had to get a little creative with `Task.Run` to explicitly handle requests concurrently.